### PR TITLE
Running examples from fresh checkout fails

### DIFF
--- a/examples/ex1_wprcnt/test_verilogs/test_wprcnt.py
+++ b/examples/ex1_wprcnt/test_verilogs/test_wprcnt.py
@@ -35,6 +35,10 @@ def _prep_cosim(args, **sigs):
     # get the handle to the
     print("cosimulation setup ...")
     cmd = "vvp -m ./myhdl.vpi wprcnt"
+
+    if not os.path.exists("vcd"):
+        os.makedirs("vcd")
+
     return Cosimulation(cmd, **sigs)
 
 

--- a/examples/ex2_mathadds/test_verilogs/test_mathadds.py
+++ b/examples/ex2_mathadds/test_verilogs/test_mathadds.py
@@ -36,6 +36,10 @@ def _prep_cosim(args, **sigs):
     # get the handle to the
     print("cosimulation setup ...")
     cmd = "vvp -m ./myhdl.vpi mathadds"
+
+    if not os.path.exists("vcd"):
+        os.makedirs("vcd")
+
     return Cosimulation(cmd, **sigs)
 
 

--- a/examples/ex3_zpexgcd/test_verilogs/test_gcd.py
+++ b/examples/ex3_zpexgcd/test_verilogs/test_gcd.py
@@ -26,6 +26,10 @@ def _prep_cosim(args, **sigs):
     # get the handle to the
     print("cosimulation setup ...")
     cmd = "vvp -m ./myhdl.vpi gcd"
+
+    if not os.path.exists("vcd"):
+        os.makedirs("vcd")
+
     return Cosimulation(cmd, **sigs)
 
 def test_gcd(args=None):

--- a/examples/ex4_mathsop/test_verilogs/test_mathsop.py
+++ b/examples/ex4_mathsop/test_verilogs/test_mathsop.py
@@ -45,6 +45,10 @@ def _prep_cosim(args, **sigs):
     # get the handle to the
     print("cosimulation setup ...")
     cmd = "vvp -m ./myhdl.vpi mathsop"
+
+    if not os.path.exists("vcd"):
+        os.makedirs("vcd")
+
     return Cosimulation(cmd, **sigs)
 
 
@@ -149,6 +153,9 @@ def test_mathsop_verilogs(args):
         ax.set_yticklabels(('-.5FS', '0', '.5FS',))
 
     # save the figure
+    if not os.path.exists("plots"):
+        os.makedirs("plots")
+
     for ext in ('png','pdf',):
         fig.savefig("plots/mathsop_time_response.%s"%(ext))
     raw_input("continue")

--- a/examples/ex6_vgasys/test_verilogs/test_vgasys.py
+++ b/examples/ex6_vgasys/test_verilogs/test_vgasys.py
@@ -37,6 +37,9 @@ def _prep_cosim(
     cmd = "iverilog -o vgasys %s " % (" ".join(files))
     os.system(cmd)
 
+    if not os.path.exists("vcd"):
+        os.makedirs("vcd")
+
     print("cosimulation setup ...")
     cmd = "vvp -m ./myhdl.vpi vgasys"
     gcosim = Cosimulation(cmd,


### PR DESCRIPTION
Icarus doesn't create the `vcd` directory, so running any of the examples from a fresh checkout fails with the following error:

```
compiling ...
cosimulation setup ...
VCD Error: tb_vgasys.v:17: Unable to open vcd/_tb_vgasys.vcd for output.
Traceback (most recent call last):
  File "test_vgasys.py", line 129, in <module>
    test_vgasys(Namespace())
  File "test_vgasys.py", line 73, in test_vgasys
    bvga, cvga, mvga)
  File "test_vgasys.py", line 49, in _prep_cosim
    mm_pxlen=mvga.pxlen, mm_active=mvga.active
  File "/usr/lib/python2.7/site-packages/myhdl/_Cosimulation.py", line 88, in __init__
    raise CosimulationError(_error.SimulationEnd)
myhdl.CosimulationError: Premature simulation end
```

These changes create the `vcd` directory during `_prep_cosim` and also create the `plots` directory for `ex4_mathsop`.  Note I haven't updated `ex5_medfilt` since this fails for another reason and therefore I can't test the change.
